### PR TITLE
fix: make home page responsive

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,8 +3,13 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 
 const Hero = () => (
-  <Box sx={{ textAlign: 'center', py: 8 }}>
-    <Typography variant="h2" component="h1" gutterBottom>
+  <Box sx={{ textAlign: 'center', py: { xs: 4, md: 8 }, px: 2 }}>
+    <Typography
+      variant="h2"
+      component="h1"
+      gutterBottom
+      sx={{ fontSize: { xs: '2rem', md: '3.5rem' } }}
+    >
       Welcome to my Portfolio
     </Typography>
     <Button variant="contained">Get Started</Button>

--- a/src/index.css
+++ b/src/index.css
@@ -24,10 +24,11 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+}
+
+#root {
+  width: 100%;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- remove global flex styling so root expands to full width
- add responsive spacing and typography to hero section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c7e85ef6c8326950cad97a7c3b061