### PR TITLE
feat: add Material UI navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,28 @@
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import Box from '@mui/material/Box';
 
 const Navbar = () => (
-  <AppBar position="static">
-    <Toolbar>
+  <AppBar
+    position="sticky"
+    color="transparent"
+    elevation={0}
+    sx={{ boxShadow: 'none' }}
+  >
+    <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
       <Typography variant="h6" component="div">
-        My Portfolio
+        Mi Portfolio
       </Typography>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Link href="#proyectos" color="inherit" underline="none">
+          Proyectos
+        </Link>
+        <Link href="#contacto" color="inherit" underline="none">
+          Contacto
+        </Link>
+      </Box>
     </Toolbar>
   </AppBar>
 );


### PR DESCRIPTION
## Summary
- add sticky, transparent navbar with portfolio links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c856e30fc83269f07171dbda4065a