### PR TITLE
feat: add custom Material UI theme

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,11 +4,14 @@ const theme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: '#1976d2',
+      main: '#000000',
     },
     secondary: {
-      main: '#9c27b0',
+      main: '#F50057',
     },
+  },
+  typography: {
+    fontFamily: ['Inter', 'Roboto', 'sans-serif'].join(','),
   },
 });
 


### PR DESCRIPTION
## Summary
- add Material UI theme in light mode with black primary and pink secondary colors
- set typography to use Inter or Roboto fonts

## Testing
- `npm test` (fails: missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c979ae484832691b53a9066f698e3