### PR TITLE
Wrap app with MUI ThemeProvider and CssBaseline

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
 import './index.css'
+import theme from './theme/theme.ts'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- wrap root with MUI `ThemeProvider` using the project's custom theme
- add `CssBaseline` for consistent global styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca12fa0708326aab6f3aa99302065