### PR TITLE
feat: add projects grid component

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,18 @@
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import projects from '../data/projects';
+import ProjectCard from './ProjectCard';
+
+const Projects = () => (
+  <Box sx={{ p: 4 }}>
+    <Grid container spacing={2} justifyContent="center">
+      {projects.map((project) => (
+        <Grid item key={project.title} xs={12} sm={6} md={4}>
+          <ProjectCard {...project} />
+        </Grid>
+      ))}
+    </Grid>
+  </Box>
+);
+
+export default Projects;


### PR DESCRIPTION
## Summary
- add `Projects` component that displays project cards in a centered, padded grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden when fetching @emotion/react)*

------
https://chatgpt.com/codex/tasks/task_e_689dc505a30c832688796bd9774e6bf7