### PR TITLE
feat: add About and Footer components

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,19 @@
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+
+const About = () => (
+  <Box id="about" sx={{ py: 4 }}>
+    <Container maxWidth="sm">
+      <Typography variant="h4" component="h2" gutterBottom align="center">
+        Sobre mí
+      </Typography>
+      <Typography variant="body1" align="center">
+        Soy un desarrollador web apasionado por crear experiencias digitales
+        simples y efectivas.
+      </Typography>
+    </Container>
+  </Box>
+);
+
+export default About;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,37 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import EmailIcon from '@mui/icons-material/Email';
+
+const Footer = () => (
+  <Box component="footer" sx={{ textAlign: 'center', py: 2 }}>
+    <Typography variant="body2" color="text.secondary" gutterBottom>
+      © {new Date().getFullYear()} Mi Portfolio
+    </Typography>
+    <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1 }}>
+      <IconButton
+        href="https://github.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="GitHub"
+      >
+        <GitHubIcon />
+      </IconButton>
+      <IconButton
+        href="https://linkedin.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="LinkedIn"
+      >
+        <LinkedInIcon />
+      </IconButton>
+      <IconButton href="mailto:example@example.com" aria-label="Email">
+        <EmailIcon />
+      </IconButton>
+    </Box>
+  </Box>
+);
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add About section with centered bio text
- implement centered Footer with copyright and GitHub/LinkedIn/Email icons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3b8af9083268bb695475a17300c