### PR TITLE
feat: add color mode context

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,27 @@
-import { StrictMode, useState } from 'react'
+import { StrictMode, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import './index.css'
 import { getDesignTokens } from './theme/theme.ts'
+import { ColorModeContext } from './theme/ColorModeContext.tsx'
 import App from './App.tsx'
 
 const Main = () => {
-  const [mode] = useState<'light' | 'dark'>('light')
-  const theme = createTheme(getDesignTokens(mode))
+  const [mode, setMode] = useState<'light' | 'dark'>('light')
+  const colorMode = {
+    toggleColorMode: () => {
+      setMode(prev => (prev === 'light' ? 'dark' : 'light'))
+    },
+  }
+  const theme = useMemo(() => createTheme(getDesignTokens(mode)), [mode])
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
+    </ColorModeContext.Provider>
   )
 }
 

--- a/src/theme/ColorModeContext.tsx
+++ b/src/theme/ColorModeContext.tsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+export const ColorModeContext = createContext<{ toggleColorMode: () => void }>({
+  toggleColorMode: () => {},
+})
+
+export default ColorModeContext


### PR DESCRIPTION
## Summary
- add ColorModeContext to manage light and dark themes
- wrap ThemeProvider with ColorModeContext.Provider and toggle logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68a10e6f0174832682b61675907e3cb2