### PR TITLE
Add Contact form component with EmailJS integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^19.1.1",
     "@mui/material": "^5.15.0",
     "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.1"
+    "@emotion/styled": "^11.11.1",
+    "@emailjs/browser": "^4.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,71 @@
+import { useRef } from 'react';
+import emailjs from '@emailjs/browser';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+const Contact = () => {
+  const form = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!form.current) return;
+
+    emailjs
+      .sendForm('service_f667bpy', 'template_96np6vh', form.current, {
+        publicKey: '4ayS8Jn7pDakd4cLw',
+      })
+      .then(
+        () => {
+          alert('Mensaje enviado con éxito.');
+          form.current?.reset();
+        },
+        () => {
+          alert('Hubo un error al enviar el mensaje.');
+        },
+      );
+  };
+
+  return (
+    <Box id="contact" sx={{ py: 4 }}>
+      <Container maxWidth="sm">
+        <Typography variant="h4" component="h2" gutterBottom align="center">
+          Contacto
+        </Typography>
+        <Box component="form" ref={form} onSubmit={handleSubmit} noValidate>
+          <TextField
+            label="Nombre"
+            name="user_name"
+            fullWidth
+            margin="normal"
+            required
+          />
+          <TextField
+            label="Email"
+            name="user_email"
+            type="email"
+            fullWidth
+            margin="normal"
+            required
+          />
+          <TextField
+            label="Mensaje"
+            name="message"
+            multiline
+            rows={4}
+            fullWidth
+            margin="normal"
+            required
+          />
+          <Button type="submit" variant="contained" sx={{ mt: 2 }} fullWidth>
+            Enviar
+          </Button>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default Contact;

--- a/src/emailjs.d.ts
+++ b/src/emailjs.d.ts
@@ -1,0 +1,2 @@
+declare module '@emailjs/browser';
+export {}


### PR DESCRIPTION
## Summary
- add Contact component with Material UI form and EmailJS sendForm integration
- declare EmailJS module to satisfy TypeScript
- register @emailjs/browser dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a11782ff348326b65a85a26ab0040f