### PR TITLE
Add TechStack component

### DIFF
--- a/src/components/TechStack.tsx
+++ b/src/components/TechStack.tsx
@@ -1,0 +1,38 @@
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+
+const technologies = [
+  'React',
+  'TypeScript',
+  'Vite',
+  'Material UI',
+  'Node.js',
+  'Express',
+  'MongoDB',
+  'Git',
+  'GitHub',
+];
+
+const TechStack = () => (
+  <Box id="tech-stack" sx={{ py: 4 }}>
+    <Container maxWidth="md">
+      <Typography variant="h4" component="h2" gutterBottom align="center">
+        Habilidades
+      </Typography>
+      <Grid container spacing={2} justifyContent="center">
+        {technologies.map((tech) => (
+          <Grid item key={tech}>
+            <Paper sx={{ p: 2, bgcolor: 'primary.main', color: 'common.white', textAlign: 'center' }}>
+              {tech}
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  </Box>
+);
+
+export default TechStack;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,11 +1,13 @@
 import Hero from '../components/Hero';
 import About from '../components/About';
+import TechStack from '../components/TechStack';
 import Projects from '../components/Projects';
 
 const Home = () => (
   <>
     <Hero />
     <About />
+    <TechStack />
     <Projects />
   </>
 );


### PR DESCRIPTION
## Summary
- add TechStack section with Material UI grid and styled items
- include TechStack between About and Projects on Home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68a2648a44588326888eb0b02ade02b1