### PR TITLE
feat: theme-aware background for Hero component

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,7 +4,15 @@ import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 
 const Hero = () => (
-  <Box id="hero" sx={{ textAlign: 'center', py: { xs: 4, md: 8 }, px: 2 }}>
+  <Box
+    id="hero"
+    sx={(theme) => ({
+      textAlign: 'center',
+      py: { xs: 4, md: 8 },
+      px: 2,
+      backgroundColor: theme.palette.background.paper,
+    })}
+  >
     <Typography
       variant="h2"
       component="h1"

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -9,7 +9,7 @@ export const getDesignTokens = (mode: 'light' | 'dark'): ThemeOptions => ({
           secondary: { main: '#ff4081' },
           background: {
             default: '#f0f2f5',
-            paper: '#ffffff',
+            paper: '#e3e7ec',
           },
           text: {
             primary: '#1e1e1e',


### PR DESCRIPTION
## Summary
- use theme paper color for Hero background
- set light mode paper background to `#e3e7ec`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aa27fc2b8c83268c3a59a290c13dc8