### PR TITLE
Add SocialSidebar with fixed social links

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.1",
     "@emailjs/browser": "^4.4.1",
-    "@fontsource/poppins": "^5.0.0"
+    "@fontsource/poppins": "^5.0.0",
+    "react-icons": "^4.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import Home from './pages/Home';
+import SocialSidebar from './components/SocialSidebar';
 
 function App() {
   return (
     <>
+      <SocialSidebar />
       <Navbar />
       <Home />
       <Footer />

--- a/src/components/SocialSidebar.tsx
+++ b/src/components/SocialSidebar.tsx
@@ -1,0 +1,39 @@
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import { FaGithub, FaLinkedin, FaTwitter, FaYoutube, FaBook } from 'react-icons/fa';
+
+const links = [
+  { href: 'https://www.linkedin.com', icon: <FaLinkedin /> },
+  { href: 'https://twitter.com', icon: <FaTwitter /> },
+  { href: 'https://www.youtube.com', icon: <FaYoutube /> },
+  { href: 'https://github.com', icon: <FaGithub /> },
+  { href: '/cv.pdf', icon: <FaBook /> },
+];
+
+const SocialSidebar = () => (
+  <Box
+    sx={{
+      position: 'fixed',
+      top: '40%',
+      left: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 1,
+    }}
+  >
+    {links.map(({ href, icon }) => (
+      <IconButton
+        key={href}
+        component="a"
+        href={href}
+        target="_blank"
+        rel="noopener"
+        color="inherit"
+      >
+        {icon}
+      </IconButton>
+    ))}
+  </Box>
+);
+
+export default SocialSidebar;


### PR DESCRIPTION
## Summary
- add SocialSidebar component with fixed vertical social icons
- render SocialSidebar ahead of the Navbar for global visibility
- include react-icons dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa43e7a83883269ac99766c58a9ec5