### PR TITLE
Focus home page on Hero section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import Navbar from './components/Navbar';
-import Footer from './components/Footer';
+// import Footer from './components/Footer';
 import Home from './pages/Home';
 import SocialSidebar from './components/SocialSidebar';
 
@@ -9,7 +9,7 @@ function App() {
       <SocialSidebar />
       <Navbar />
       <Home />
-      <Footer />
+      {/* <Footer /> */}
     </>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,6 +7,7 @@ const Hero = () => (
   <Box
     id="hero"
     sx={(theme) => ({
+      height: '100vh',
       textAlign: 'center',
       py: { xs: 4, md: 8 },
       px: 2,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,14 +1,16 @@
 import Hero from '../components/Hero';
-import About from '../components/About';
-import TechStack from '../components/TechStack';
-import Projects from '../components/Projects';
+// import About from '../components/About';
+// import TechStack from '../components/TechStack';
+// import Projects from '../components/Projects';
+// import Contact from '../components/Contact';
 
 const Home = () => (
   <>
     <Hero />
-    <About />
-    <TechStack />
-    <Projects />
+    {/* <About /> */}
+    {/* <TechStack /> */}
+    {/* <Projects /> */}
+    {/* <Contact /> */}
   </>
 );
 


### PR DESCRIPTION
## Summary
- show only Hero section on the home page
- expand Hero component to fill full viewport height
- display only Navbar, SocialSidebar, and Home in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emailjs%2fbrowser)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c6ff640832689ca8d71e1f9646e