### PR TITLE
Improve project and about section spacing

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -83,6 +83,7 @@ const About = () => (
         </Grid>
       </Grid>
     </Container>
+    <Box mt={8} />
   </Box>
 );
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -17,6 +17,7 @@ const ProjectCard = ({ title, description, image, url, isReversed = false }: Pro
     container
     spacing={4}
     direction={isReversed ? 'row-reverse' : 'row'}
+    justifyContent="center"
     alignItems="center"
     component={motion.div}
     initial={{ opacity: 0, x: isReversed ? 50 : -50 }}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,17 +1,20 @@
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
 import projects from '../data/projects';
 import ProjectCard from './ProjectCard';
 
 const Projects = () => (
-  <Box id="projects" sx={{ py: 10 }}>
+  <Box id="projects" sx={{ py: 8, bgcolor: '#f7f9fc' }}>
     <Container maxWidth="lg">
       {projects.map((project, index) => (
-        <ProjectCard
-          key={project.title}
-          {...project}
-          isReversed={index % 2 === 1}
-        />
+        <Box key={project.title} mb={10}>
+          <ProjectCard
+            {...project}
+            isReversed={index % 2 === 1}
+          />
+          {index !== projects.length - 1 && <Divider />}
+        </Box>
       ))}
     </Container>
   </Box>


### PR DESCRIPTION
## Summary
- Add background color and spacing tweaks to Projects section
- Center ProjectCard content and add dividers between cards
- Give About section extra bottom margin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8491ac8508326bc3ef7126b43d687