### PR TITLE
Add dark-mode styling and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import Navbar from './components/Navbar';
-// import Footer from './components/Footer';
+import Footer from './components/Footer';
 import Home from './pages/Home';
 import SocialSidebar from './components/SocialSidebar';
 
@@ -9,7 +9,7 @@ function App() {
       <SocialSidebar />
       <Navbar />
       <Home />
-      {/* <Footer /> */}
+      <Footer />
     </>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -83,7 +83,7 @@ const About = () => (
         </Grid>
       </Grid>
     </Container>
-    <Box mt={8} />
+    <Box mt={5} />
   </Box>
 );
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,37 +1,29 @@
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
-import GitHubIcon from '@mui/icons-material/GitHub';
-import LinkedInIcon from '@mui/icons-material/LinkedIn';
-import EmailIcon from '@mui/icons-material/Email';
+import { useTheme } from '@mui/material/styles';
 
-const Footer = () => (
-  <Box component="footer" sx={{ textAlign: 'center', py: 2 }}>
-    <Typography variant="body2" color="text.secondary" gutterBottom>
-      © {new Date().getFullYear()} Mi Portfolio
-    </Typography>
-    <Box sx={{ display: 'flex', justifyContent: 'center', gap: 1 }}>
-      <IconButton
-        href="https://github.com/"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="GitHub"
-      >
-        <GitHubIcon />
-      </IconButton>
-      <IconButton
-        href="https://linkedin.com/"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="LinkedIn"
-      >
-        <LinkedInIcon />
-      </IconButton>
-      <IconButton href="mailto:example@example.com" aria-label="Email">
-        <EmailIcon />
-      </IconButton>
+const Footer = () => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        textAlign: 'center',
+        py: 2,
+        backgroundColor:
+          theme.palette.mode === 'dark' ? '#121212' : '#f7f9fc',
+        color: theme.palette.mode === 'dark' ? '#f1f1f1' : 'inherit',
+      }}
+    >
+      <Typography variant="body2">
+        © {new Date().getFullYear()} Mi Portfolio
+      </Typography>
+      <Typography variant="body2">
+        Built with React, TypeScript, and Material UI.
+      </Typography>
     </Box>
-  </Box>
-);
+  );
+};
 
 export default Footer;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -38,7 +38,7 @@ const ProjectCard = ({ title, description, image, url, isReversed = false }: Pro
       <Typography variant="h5" gutterBottom>
         {title}
       </Typography>
-      <Typography variant="body1" color="text.secondary" paragraph>
+      <Typography variant="body1" paragraph>
         {description}
       </Typography>
       <Button

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,23 +1,33 @@
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
+import { useTheme } from '@mui/material/styles';
 import projects from '../data/projects';
 import ProjectCard from './ProjectCard';
 
-const Projects = () => (
-  <Box id="projects" sx={{ py: 8, bgcolor: '#f7f9fc' }}>
-    <Container maxWidth="lg">
-      {projects.map((project, index) => (
-        <Box key={project.title} mb={10}>
-          <ProjectCard
-            {...project}
-            isReversed={index % 2 === 1}
-          />
-          {index !== projects.length - 1 && <Divider />}
-        </Box>
-      ))}
-    </Container>
-  </Box>
-);
+const Projects = () => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      id="projects"
+      sx={{
+        py: 8,
+        backgroundColor:
+          theme.palette.mode === 'dark' ? '#121212' : '#f7f9fc',
+        color: theme.palette.mode === 'dark' ? '#f1f1f1' : 'inherit',
+      }}
+    >
+      <Container maxWidth="lg">
+        {projects.map((project, index) => (
+          <Box key={project.title} mb={6}>
+            <ProjectCard {...project} isReversed={index % 2 === 1} />
+            {index !== projects.length - 1 && <Divider />}
+          </Box>
+        ))}
+      </Container>
+    </Box>
+  );
+};
 
 export default Projects;


### PR DESCRIPTION
## Summary
- make project section theme-aware and streamline spacing
- add simple theme-adaptive footer and display it in the app
- let project text inherit container color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b84d9a63248326bddd63c75c1cbf79