### PR TITLE
Add scroll indicator and back-to-top control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import Home from './pages/Home';
 import SocialSidebar from './components/SocialSidebar';
+import BackToTop from './components/BackToTop';
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <SocialSidebar />
       <Navbar />
       <Home />
+      <BackToTop />
       <Footer />
     </>
   );

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import IconButton from '@mui/material/IconButton';
+import { FiChevronUp as ChevronUp } from 'react-icons/fi';
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setVisible(window.scrollY > 300);
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.3 }}
+      style={{ position: 'fixed', bottom: 16, right: 16, zIndex: 1000 }}
+    >
+      <IconButton onClick={scrollToTop} color="primary" aria-label="back to top">
+        <ChevronUp />
+      </IconButton>
+    </motion.div>
+  );
+};
+
+export default BackToTop;

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,7 +1,9 @@
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
+import { motion } from 'framer-motion';
 import projects from '../data/projects';
 import ProjectCard from './ProjectCard';
 
@@ -21,6 +23,17 @@ const Projects = () => {
         }}
       >
         <Container maxWidth="lg">
+          <Box mb={4} display="flex" justifyContent="center">
+            <Typography
+              component={motion.div}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: [0, 1, 0] }}
+              transition={{ repeat: Infinity, duration: 2 }}
+              align="center"
+            >
+              ↓ Keep Scrolling ↓
+            </Typography>
+          </Box>
           {projects.map((project, index) => (
             <Box key={project.title} mb={4}>
               <ProjectCard {...project} isReversed={index % 2 === 1} />


### PR DESCRIPTION
## Summary
- add animated "Keep Scrolling" indicator before project grid
- introduce BackToTop component that appears after scrolling and returns page to top
- render BackToTop above footer for global access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a4cc30d48326a034397a7505ed22